### PR TITLE
#5877:  Add backward support for Leaky_relu

### DIFF
--- a/docs/source/ttnn/dependencies/tt_lib.rst
+++ b/docs/source/ttnn/dependencies/tt_lib.rst
@@ -944,6 +944,8 @@ Backward Operations
 
 .. autofunction:: tt_lib.tensor.acos_bw
 
+.. autofunction:: tt_lib.tensor.leaky_relu_bw
+
 Loss Functions
 ==============
 

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_leaky_relu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_leaky_relu.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+import tt_lib
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    (
+        (torch.Size([1, 1, 32, 32])),
+        (torch.Size([1, 1, 320, 384])),
+        (torch.Size([1, 3, 320, 384])),
+    ),
+)
+@pytest.mark.parametrize("negative_slope", [-0.25, -0.5, 0.01, 0.5, 5.0])
+def test_bw_leaky_relu(input_shapes, negative_slope, device):
+    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
+    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+
+    pyt_y = torch.nn.functional.leaky_relu(in_data, negative_slope=negative_slope, inplace=False)
+
+    tt_output_tensor_on_device = tt_lib.tensor.leaky_relu_bw(grad_tensor, input_tensor, negative_slope)
+
+    in_data.retain_grad()
+
+    pyt_y.backward(gradient=grad_data)
+
+    golden_tensor = [in_data.grad]
+    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -985,6 +985,19 @@ std::vector<Tensor> acos_bw(const Tensor& grad, const Tensor& input, const Memor
     return operation::decorate_as_composite(__func__, _acos_bw)(grad, input, output_mem_config);
 }
 
+// Leaky_Relu
+// result: torch.where(self > 0, grad_output, grad_output * negative_slope)
+std::vector<Tensor> _leaky_relu_bw(const Tensor& grad, const Tensor& input, float negative_slope, const MemoryConfig& output_mem_config) {
+    std::vector<Tensor> grad_tensor;
+    Tensor grad_result = where(gtz(input, output_mem_config), grad, mul_unary(grad, negative_slope, output_mem_config), output_mem_config);
+
+    grad_tensor.emplace_back(grad_result);
+    return grad_tensor;
+}
+std::vector<Tensor> leaky_relu_bw(const Tensor& grad, const Tensor& input, float negative_slope, const MemoryConfig& output_mem_config)
+{
+    return operation::decorate_as_composite(__func__, _leaky_relu_bw)(grad, input, negative_slope, output_mem_config);
+}
 }//namespace tt_metal
 
 }//namespace tt

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.hpp
@@ -153,6 +153,8 @@ std::vector<Tensor> acosh_bw(const Tensor& grad, const Tensor& input, const Memo
 
 std::vector<Tensor> acos_bw(const Tensor& grad, const Tensor& input, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
 
+std::vector<Tensor> leaky_relu_bw(const Tensor& grad, const Tensor& input, float negative_slope, const MemoryConfig& output_mem_config = operation::DEFAULT_OUTPUT_MEMORY_CONFIG);
+
 } //namespace tt_metal
 
 } //namespace tt

--- a/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
+++ b/tt_eager/tt_lib/csrc/tt_lib_bindings_tensor_backward_ops.cpp
@@ -993,6 +993,22 @@ namespace tt::tt_metal::detail{
                 "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
         )doc");
 
+    m_tensor.def("leaky_relu_bw", &tt::tt_metal::leaky_relu_bw,
+            py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("negative_slope") = 0.01f, py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
+            Performs backward operations for leaky_relu_bw of ``input`` tensor with given ``grad``.
+
+            Input tensors must have BFLOAT16 data type.
+
+            Output tensors will have BFLOAT16 data type.
+
+            .. csv-table::
+                :header: "Argument", "Description", "Data type", "Valid range", "Required"
+
+                "grad", "Gradient tensor", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "input", "Tensor leaky_relu_bw is applied to", "Tensor", "Tensor of shape [W, Z, Y, X]", "Yes"
+                "output_mem_config", "Layout of tensor in TT Accelerator device memory banks", "MemoryConfig", "Default is interleaved in DRAM", "No"
+        )doc");
+
     m_tensor.def("i0_bw", &tt::tt_metal::i0_bw,
             py::arg("grad").noconvert(), py::arg("input").noconvert(), py::arg("output_mem_config").noconvert() = operation::DEFAULT_OUTPUT_MEMORY_CONFIG, R"doc(
             Performs backward operations for i0 of ``input`` and tensor with given ``grad``.


### PR DESCRIPTION
Added the backward support for Leaky_relu op

```
Leaky_Relu
result: torch.where(self > 0, grad_output, grad_output * negative_slope)
```