### PR TITLE
#6443: Fix sqrt and update backward ops silu, selu, tan, tanh, tanhshrink

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_selu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_selu.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_selu(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
 
     pyt_y = torch.nn.functional.selu(in_data)
 
@@ -29,6 +29,6 @@ def test_bw_selu(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
 
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sigmoid.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_sigmoid(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1, 1, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -100, 100, device, True)
 
     pyt_y = torch.sigmoid(in_data)
 
@@ -30,5 +30,5 @@ def test_bw_sigmoid(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor, 0.90)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor, 0.90)
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_silu.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_silu.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_silu(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
 
     pyt_y = torch.nn.functional.silu(in_data)
 
@@ -29,6 +29,6 @@ def test_bw_silu(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
 
     assert comp_pass

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_sqrt.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_sqrt(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
 
     pyt_y = torch.sqrt(in_data)
 
@@ -29,5 +29,5 @@ def test_bw_sqrt(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    status = compare_results(tt_output_tensor_on_device, golden_tensor)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tan.py
@@ -5,7 +5,10 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_pt_tt, compare_results
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import (
+    data_gen_with_range,
+    compare_results,
+)
 
 
 @pytest.mark.parametrize(
@@ -17,13 +20,10 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_tan(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
     # tt tan supports input range [-1.45, 1.45]
-    in_data = torch.Tensor(size=input_shapes).uniform_(-1.45, 1.45)
-    in_data.requires_grad = True
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
+
     pyt_y = torch.tan(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.tan_bw(grad_tensor, input_tensor)

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanh.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import data_gen_with_range, compare_pcc
 
 
 @pytest.mark.parametrize(
@@ -17,8 +17,9 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_tanh(input_shapes, device):
-    in_data, input_tensor = data_gen_pt_tt(input_shapes, device, True)
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
+    # tt tan supports input range [-1.45, 1.45]
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1.45, 1.45, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
     pyt_y = torch.tanh(in_data)
 
     tt_output_tensor_on_device = tt_lib.tensor.tanh_bw(grad_tensor, input_tensor)
@@ -29,5 +30,5 @@ def test_bw_tanh(input_shapes, device):
 
     golden_tensor = [in_data.grad]
 
-    status = compare_results(tt_output_tensor_on_device, golden_tensor, 0.95)
+    status = compare_pcc(tt_output_tensor_on_device, golden_tensor, 0.95)
     assert status

--- a/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanhshrink.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/backward_ops/test_backward_tanhshrink.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 import tt_lib
-from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_results, data_gen_pt_tt
+from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs import compare_pcc, data_gen_with_range
 
 
 @pytest.mark.parametrize(
@@ -17,12 +17,8 @@ from tests.tt_eager.python_api_testing.unit_testing.backward_ops.utility_funcs i
     ),
 )
 def test_bw_tanhshrink(input_shapes, device):
-    grad_data, grad_tensor = data_gen_pt_tt(input_shapes, device)
-    in_data = torch.Tensor(size=input_shapes).uniform_()
-    in_data.requires_grad = True
-    input_tensor = (
-        tt_lib.tensor.Tensor(in_data, tt_lib.tensor.DataType.BFLOAT16).to(tt_lib.tensor.Layout.TILE).to(device)
-    )
+    in_data, input_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device, True)
+    grad_data, grad_tensor = data_gen_with_range(input_shapes, -1e4, 1e4, device)
 
     pyt_y = torch.nn.functional.tanhshrink(in_data)
     tt_output_tensor_on_device = tt_lib.tensor.tanhshrink_bw(grad_tensor, input_tensor)
@@ -32,5 +28,5 @@ def test_bw_tanhshrink(input_shapes, device):
     pyt_y.backward(gradient=grad_data)
 
     golden_tensor = [in_data.grad]
-    comp_pass = compare_results(tt_output_tensor_on_device, golden_tensor)
+    comp_pass = compare_pcc(tt_output_tensor_on_device, golden_tensor)
     assert comp_pass

--- a/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
+++ b/tt_eager/tt_dnn/op_library/backward/backward_ops.cpp
@@ -152,7 +152,7 @@ std::vector<Tensor> _sqrt_bw(const Tensor& grad, const Tensor& input, const Memo
     Tensor sqrt_result = sqrt(input, output_mem_config);
     Tensor result = mul(grad, recip(mul_unary(sqrt_result, 2.0, output_mem_config), output_mem_config), std::nullopt, output_mem_config);
     float t_nan  = std::nanf("");
-    result = where(ltz(input, output_mem_config), t_nan, result, output_mem_config);
+    result = where(lez(input, output_mem_config), t_nan, result, output_mem_config);
     grad_tensor.emplace_back(result);
     return grad_tensor;
 }


### PR DESCRIPTION
Handled nan issues in **sqrt** op

* Backward ops

- silu
- selu
- tan
- tanh
- tanhshrink
- sigmoid (It has low accuracy from TT hence I fixed from -1 to 1)